### PR TITLE
Create Build and Push pipelines for CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: '19.3'
-      - name: Install deps and build static site
         run: |
           cd site
           npm ci

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,10 @@ jobs:
     - name: Test step to show dir contents
       run: ls -l && ls -l www
     - name: Download and run terraform
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AccessKeyId }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AccessKeySecret }}
+        AWS_DEFAULT_REGION: ${{ secrets.Region }}
       run: |
         curl -o terraform.zip https://releases.hashicorp.com/terraform/1.3.7/terraform_1.3.7_linux_amd64.zip
         unzip terraform.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,9 +41,10 @@ jobs:
       uses: actions/download-artifact@v3
     - name: Download and run terraform
       run: |
-        curl -o terraform.zip https://releases.hashicorp.com/terraform/1.3.7/terraform_1.3.7_linux_amd64.zip
-        unzip terraform.zip
+        # curl -o terraform.zip https://releases.hashicorp.com/terraform/1.3.7/terraform_1.3.7_linux_amd64.zip
+        # unzip terraform.zip
         cd infra
+        terraform -version
         terraform init
         terraform plan -out=plan
     - name: Upload build artifacts to s3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,18 +12,15 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [19.x]
-
     steps:
-    - uses: actions/checkout@v3
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
-      with:
-        node-version: ${{ matrix.node-version }}
-        cache: 'npm'
-    - run: npm run build --if-present
+      - uses: actions/checkout@v3
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '19.3'
+      - run: |
+          cd site
+          npm run build --if-present
 
   plan:
   

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,3 @@
-# This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
-
 name: PR Build
 
 on:
@@ -23,6 +20,7 @@ jobs:
           npm run build --if-present
 
   plan:
+    needs: build
   
     runs-on: ubuntu-latest
     

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,14 +11,20 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Use Node.js
+      - name: Build Node.js artifacts
         uses: actions/setup-node@v3
         with:
           node-version: '19.3'
-      - run: |
+      - name: Install deps and build static site
+        run: |
           cd site
           npm ci
           npm run build --if-present
+      - name: Upload artifacts for plan
+        uses: actions/upload-artifact@v3
+        with:
+          name: site
+          path: out
 
   plan:
     needs: build
@@ -27,7 +33,14 @@ jobs:
     
     steps:
     - uses: actions/checkout@v3
-    - run: |
+    - name: Download artifacts from build
+      uses: actions/download-artifact@v3
+      with:
+        name: site
+    - name: Test step to show dir contents
+      run: ls -l
+    - name: Download and run terraform
+      run: |
         curl -o terraform.zip https://releases.hashicorp.com/terraform/1.3.7/terraform_1.3.7_linux_amd64.zip
         unzip terraform.zip
         cd infra

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,21 +29,25 @@ jobs:
     needs: build
   
     runs-on: ubuntu-latest
-    
+
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AccessKeyId }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AccessKeySecret }}
+      AWS_DEFAULT_REGION: ${{ secrets.Region }}
+
     steps:
     - uses: actions/checkout@v3
     - name: Download artifacts from build
       uses: actions/download-artifact@v3
-    - name: Test step to show dir contents
-      run: ls -l && ls -l www
     - name: Download and run terraform
-      env:
-        AWS_ACCESS_KEY_ID: ${{ secrets.AccessKeyId }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AccessKeySecret }}
-        AWS_DEFAULT_REGION: ${{ secrets.Region }}
       run: |
         curl -o terraform.zip https://releases.hashicorp.com/terraform/1.3.7/terraform_1.3.7_linux_amd64.zip
         unzip terraform.zip
         cd infra
         terraform init
         terraform plan -out=plan
+    - name: Upload build artifacts to s3
+      run: |
+        apt install awscli -y
+        tar czvf output.tar.gz www/ infra/plan
+        aws s3 cp output.tar.gz s3://nijine-terraform

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,6 +48,5 @@ jobs:
         terraform plan -out=plan
     - name: Upload build artifacts to s3
       run: |
-        apt install awscli -y
         tar czvf output.tar.gz www/ infra/plan
         aws s3 cp output.tar.gz s3://nijine-terraform

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,39 @@
+# This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
+
+name: PR Build
+
+on:
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [19.x]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'npm'
+    - run: npm run build --if-present
+
+  plan:
+  
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v3
+    - run: |
+        curl -o terraform.zip https://releases.hashicorp.com/terraform/1.3.7/terraform_1.3.7_linux_amd64.zip
+        unzip terraform.zip
+        cd infra
+        terraform init
+        terraform plan -out=plan

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,8 +41,6 @@ jobs:
       uses: actions/download-artifact@v3
     - name: Download and run terraform
       run: |
-        # curl -o terraform.zip https://releases.hashicorp.com/terraform/1.3.7/terraform_1.3.7_linux_amd64.zip
-        # unzip terraform.zip
         cd infra
         terraform -version
         terraform init

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,8 +34,6 @@ jobs:
     - uses: actions/checkout@v3
     - name: Download artifacts from build
       uses: actions/download-artifact@v3
-      with:
-        name: site
     - name: Test step to show dir contents
       run: ls -l
     - name: Download and run terraform

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: '19.3'
-        run: |
+      - run: |
           cd site
           npm ci
           npm run build --if-present

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: site
-          path: out
+          path: site/out
 
   plan:
     needs: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Upload artifacts for plan
         uses: actions/upload-artifact@v3
         with:
-          name: site
+          name: www
           path: site/out
 
   plan:
@@ -35,7 +35,7 @@ jobs:
     - name: Download artifacts from build
       uses: actions/download-artifact@v3
     - name: Test step to show dir contents
-      run: ls -l
+      run: ls -l && ls -l www
     - name: Download and run terraform
       run: |
         curl -o terraform.zip https://releases.hashicorp.com/terraform/1.3.7/terraform_1.3.7_linux_amd64.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,7 @@ jobs:
           node-version: '19.3'
       - run: |
           cd site
+          npm ci
           npm run build --if-present
 
   plan:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,4 +1,4 @@
-name: Merge to main
+name: Push to main
 
 on:
   push:
@@ -28,3 +28,6 @@ jobs:
     - name: Sync www to S3
       run: |
         aws s3 sync www/ s3://loshakov.link-www
+    - name: Clean up S3
+      run: |
+        aws s3 rm s3://nijine-terraform/output.tar.gz

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -22,8 +22,6 @@ jobs:
         tar xvf output.tar.gz
     - name: Run terraform apply
       run: |
-        curl -o terraform.zip https://releases.hashicorp.com/terraform/1.3.7/terraform_1.3.7_linux_amd64.zip
-        unzip terraform.zip
         cd infra
         terraform init
         terraform apply plan

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -22,12 +22,11 @@ jobs:
         tar xvf output.tar.gz
     - name: Run terraform apply
       run: |
-        exit 1  # stop here for testing
-        # curl -o terraform.zip https://releases.hashicorp.com/terraform/1.3.7/terraform_1.3.7_linux_amd64.zip
-        # unzip terraform.zip
-        # cd infra
-        # terraform init
-        # terraform apply plan
+        curl -o terraform.zip https://releases.hashicorp.com/terraform/1.3.7/terraform_1.3.7_linux_amd64.zip
+        unzip terraform.zip
+        cd infra
+        terraform init
+        terraform apply plan
     - name: Sync www to S3
       run: |
         aws s3 sync www/ s3://loshakov.link-www

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,33 @@
+name: Merge to main
+
+on:
+  push:
+    branches: [ "main" ]
+
+jobs:
+
+  plan:
+    runs-on: ubuntu-latest
+
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AccessKeyId }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AccessKeySecret }}
+      AWS_DEFAULT_REGION: ${{ secrets.Region }}
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Retrieve artifacts from S3
+      run: |
+        aws s3 cp s3://nijine-terraform/output.tar.gz .
+        tar xvf output.tar.gz
+    - name: Run terraform apply
+      run: |
+        exit 1  # stop here for testing
+        # curl -o terraform.zip https://releases.hashicorp.com/terraform/1.3.7/terraform_1.3.7_linux_amd64.zip
+        # unzip terraform.zip
+        # cd infra
+        # terraform init
+        # terraform apply plan
+    - name: Sync www to S3
+      run: |
+        aws s3 sync www/ s3://loshakov.link-www

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -1,0 +1,26 @@
+terraform {
+  backend "s3" {
+    bucket = "nijine-terraform"
+    key    = "terraform.tfstate"
+    region = "us-east-1"
+  }
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.49"
+    }
+  }
+
+  required_version = ">= 1.2.0"
+}
+
+provider "aws" {
+  region = "us-east-1"
+}
+
+module "site" {
+  source      = "github.com/nijine/simple-cf-site"
+  domain_name = "loshakov.link"
+  www_dir     = "../www"
+}

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -22,5 +22,4 @@ provider "aws" {
 module "site" {
   source      = "github.com/nijine/simple-cf-site"
   domain_name = "loshakov.link"
-  www_dir     = "../www"
 }


### PR DESCRIPTION
Add CI to do the following:
For PRs:
- Build the next.js project
- Run a terraform plan to show changes
- Upload the next.js project static output and terraform plan file to S3

For master:
- Run a terraform apply using the plan and project output last uploaded to S3
- Clean up the intermediary assets (that we're pushed to S3)