### PR TITLE
Re-run the terraform plan (fixes an issue)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: Download artifacts from build
       uses: actions/download-artifact@v3
-    - name: Download and run terraform
+    - name: Run terraform
       run: |
         cd infra
         terraform -version


### PR DESCRIPTION
Fixed an issue with the OAC name not being unique, which caused a conflict with another existing OAC. Re-running the build.

Also updating the name on the terraform build step while I'm here.