### PR TITLE
Add function association for default cache behavior in CloudFront.

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -38,7 +38,7 @@ function handler(event) {
   var request = event.request;
   var uri = request.uri;
 
-  request.uri = `$${uri.includes(".") ? uri : uri.concat(".html")}`;
+  request.uri = `$${uri.includes(".") ? uri : uri === '/' ? uri : uri.concat(".html")}`;
 
   return request;
 }

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -23,4 +23,24 @@ module "site" {
   source       = "github.com/nijine/simple-cf-site"
   domain_name  = "loshakov.link"
   error_object = "404.html"
+
+  default_cache_func_assoc = [{
+    event_type   = "viewer-request"
+    function_arn = aws_cloudfront_function.rewrite_uri.arn
+  }]
+}
+
+resource "aws_cloudfront_function" "rewrite_uri" {
+  name    = "rewrite-request-if-page-without-dot-html"
+  runtime = "cloudfront-js-1.0"
+  code    = <<EOF
+function handler(event) {
+  var request = event.request;
+  var uri = request.uri;
+
+  request.uri = `$${uri.includes(".") ? uri : uri.concat(".html")}`;
+
+  return request;
+}
+EOF
 }


### PR DESCRIPTION
As it turns out, navigating this type of site works just fine in the browser, but if you go to share a link (and thus navigate to a page directly), there is no referrer information to make sure that the user ends up on the right page, and they end up getting the `404` page.

This adds a function that interpolates the uri to add `.html` if the request itself is missing referrer information, so that we still navigate to the right page. Works fine for this use-case.

The `terraform plan` should show no changes, since I applied the changes locally for testing.